### PR TITLE
Fixed bug in TransactionalWords example.

### DIFF
--- a/src/jvm/storm/starter/TransactionalWords.java
+++ b/src/jvm/storm/starter/TransactionalWords.java
@@ -114,7 +114,7 @@ public class TransactionalWords {
                         newVal.count = val.count;
                     }
                     newVal.count = newVal.count + _counts.get(key);
-                    COUNT_DATABASE.put(key, val);
+                    COUNT_DATABASE.put(key, newVal);
                 } else {
                     newVal = val;
                 }


### PR DESCRIPTION
I'm playing with storm for the first time and going through the examples.  I noticed that the COUNT_DATABASE in the TransactionalWords was not being updated with the proper word counts as each transaction was committed.  This is because COUNT_DATABASE.put(key, val) was being called, instead of putting newVal.  val starts as null, which means that every put just put back a null value.  Hope this helps others reading through this example.
