### PR TITLE
Update Twitter library dependencies to make the demo work again

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -11,8 +11,8 @@
 
   :dependencies [[org.clojure/clojure "1.2.0"]
                  [org.clojure/clojure-contrib "1.2.0"]
-                 [org.twitter4j/twitter4j-core "2.2.5-SNAPSHOT"]
-                 [org.twitter4j/twitter4j-stream "2.2.5-SNAPSHOT"]
+                 [org.twitter4j/twitter4j-core "2.2.6-SNAPSHOT"]
+                 [org.twitter4j/twitter4j-stream "2.2.6-SNAPSHOT"]
                  ]
 
   :dev-dependencies [[storm "0.7.1"]


### PR DESCRIPTION
I couldn't get the demo to work with the given instructions in the Readme using Leiningen, because of the unavailability of the Twitter libraries.

After using the "[2.2,)" syntax I found out that "2.2.6-SNAPSHOT" versions are available.

With this update the demo seems to work properly.

NB. I assume a similar change is also needed for the Maven part.
