### PR TITLE
SplitSentence Bolt in ruby

### DIFF
--- a/multilang/resources/splitsentence.rb
+++ b/multilang/resources/splitsentence.rb
@@ -1,0 +1,11 @@
+require "./storm"
+
+class SplitSentenceBolt < Storm::Bolt
+  def process(tup)
+    tup.values[0].split(" ").each do |word|
+      emit([word])
+    end
+  end
+end
+
+SplitSentenceBolt.new.run


### PR DESCRIPTION
I noticed the ruby version of the SplitSentence bolt was missing so I translated the splitsentence.py to ruby and tested it, I think this should be in there! (see commit)
