### PR TITLE
SlidingWindowCounterTest: add missing @Test annotation to unit test

### DIFF
--- a/test/jvm/storm/starter/tools/SlidingWindowCounterTest.java
+++ b/test/jvm/storm/starter/tools/SlidingWindowCounterTest.java
@@ -32,6 +32,7 @@ public class SlidingWindowCounterTest {
         new SlidingWindowCounter<Object>(windowLengthInSlots);
     }
 
+    @Test
     public void newInstanceShouldHaveEmptyCounts() {
         // given
         SlidingWindowCounter<Object> counter = new SlidingWindowCounter<Object>(ANY_WINDOW_LENGTH_IN_SLOTS);


### PR DESCRIPTION
Whoops, forget to add a @Test annotation for one of the unit tests.
