### PR TITLE
Ensure zeros get reported.

### DIFF
--- a/src/jvm/storm/starter/tools/SlidingWindowCounter.java
+++ b/src/jvm/storm/starter/tools/SlidingWindowCounter.java
@@ -86,6 +86,7 @@ public final class SlidingWindowCounter<T> implements Serializable {
     public Map<T, Long> getCountsThenAdvanceWindow() {
         Map<T, Long> counts = objCounter.getCounts();
         objCounter.wipeSlot(tailSlot);
+        objCounter.wipeZeros();
         advanceHead();
         return counts;
     }

--- a/src/jvm/storm/starter/tools/SlidingWindowCounter.java
+++ b/src/jvm/storm/starter/tools/SlidingWindowCounter.java
@@ -85,8 +85,8 @@ public final class SlidingWindowCounter<T> implements Serializable {
      */
     public Map<T, Long> getCountsThenAdvanceWindow() {
         Map<T, Long> counts = objCounter.getCounts();
-        objCounter.wipeSlot(tailSlot);
         objCounter.wipeZeros();
+        objCounter.wipeSlot(tailSlot);
         advanceHead();
         return counts;
     }

--- a/src/jvm/storm/starter/tools/SlotBasedCounter.java
+++ b/src/jvm/storm/starter/tools/SlotBasedCounter.java
@@ -68,21 +68,11 @@ public final class SlotBasedCounter<T> implements Serializable {
     /**
      * Reset the slot count of any tracked objects to zero for the given slot.
      * 
-     * <em>Implementation detail:</em> As an optimization this method will also remove any object from the counter whose
-     * total count is zero after the wipe of the slot (to free up memory).
-     * 
      * @param slot
      */
     public void wipeSlot(int slot) {
-        Set<T> objToBeRemoved = new HashSet<T>();
         for (T obj : objToCounts.keySet()) {
             resetSlotCountToZero(obj, slot);
-            if (shouldBeRemovedFromCounter(obj)) {
-                objToBeRemoved.add(obj);
-            }
-        }
-        for (T obj : objToBeRemoved) {
-            objToCounts.remove(obj);
         }
     }
 
@@ -93,6 +83,21 @@ public final class SlotBasedCounter<T> implements Serializable {
 
     private boolean shouldBeRemovedFromCounter(T obj) {
         return computeTotalCount(obj) == 0;
+    }
+
+    /**
+     * Remove any object from the counter whose total count is zero (to free up memory).
+     */
+    public void wipeZeros() {
+        Set<T> objToBeRemoved = new HashSet<T>();
+        for (T obj : objToCounts.keySet()) {
+            if (shouldBeRemovedFromCounter(obj)) {
+                objToBeRemoved.add(obj);
+            }
+        }
+        for (T obj : objToBeRemoved) {
+            objToCounts.remove(obj);
+        }
     }
 
 }


### PR DESCRIPTION
This change is best explained by describing the behavior of
RollingTopWords in its absence.

Let's say the word "Bieber" appears in the tweet stream at a very high
rate for half an hour, and then is _never heard again_.

This will insert the word "Bieber" into our rankings object downstream.

Note that there is nothing to _remove_ the word "Bieber" from the
rankings object downstream. Let us assume that, during its half-hour,
the word "Bieber" appears _more than five times as often_ as other
highly-ranked words. Then the very _last_ "Bieber" report (in which
"Bieber" has only appeared for the first minute of the five-minute
window) will still be able to hold a place in the rankings. Objects are
only lowered in the rankings by being outranked, or by _appearing again_
with a lower score.

_With_ this change, we wipe zeros, and _then_ wipe a slot. This means
that when we wipe the slot containing the last Bieber mentions, we
don't at that moment remove "Bieber" from our map. The _next_ report
will include "Bieber" with a score of zero, removing "Bieber" from the
ranking object downstream.
