### PR TITLE
Correct lein version in README

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -10,7 +10,7 @@ More information about Storm can be found on the [project page](http://github.co
 
 ## Running an example with Leiningen
 
-Install Leiningen by following the installation instructions [here](https://github.com/technomancy/leiningen). The storm-starter build uses Leiningen 1.7.1.
+Install Leiningen by following the installation instructions [here](https://github.com/technomancy/leiningen). The storm-starter build uses Leiningen 2.
 
 ### To run a Java example:
 


### PR DESCRIPTION
The README claims that lein 1.7.1 is used to build storm-starter, but it seems that that build has been on lein 2 since

https://github.com/nathanmarz/storm-starter/commit/8f8f48c75989ea1af3afeb8c0fe27b51b6080850
