### PR TITLE
Fix transaction id check in KeyedCountUpdater.

### DIFF
--- a/src/jvm/storm/starter/TransactionalWords.java
+++ b/src/jvm/storm/starter/TransactionalWords.java
@@ -106,7 +106,7 @@ public class TransactionalWords {
             for(String key: _counts.keySet()) {
                 CountValue val = COUNT_DATABASE.get(key);
                 CountValue newVal;
-                if(val==null || !val.txid.equals(_id)) {
+                if(val==null || !val.txid.equals(_id.getTransactionId())) {
                     newVal = new CountValue();
                     newVal.txid = _id.getTransactionId();
                     if(val!=null) {


### PR DESCRIPTION
KeyedCountUpdater#finishBatch compares a TransactionAttempt with a BigInteger TransactionId. This will always return false.
